### PR TITLE
Feature/add gql scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,12 @@
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "test:e2e": "vue-cli-service test:e2e",
-    "lint": "vue-cli-service lint"
+    "lint": "vue-cli-service lint",
+    "gql:extract": "npx apollo client:extract",
+    "gql:codegen": "npx apollo client:codegen --target=typescript",
+    "gql:schema:json": "npx apollo client:download-schema schema.json",
+    "gql:schema:gql": "npx apollo client:download-schema schema.gql",
+    "gql:generate": "npm run gql:schema:json && npm run gql:schema:gql && npm run gql:codegen && npm run gql:extract"
   },
   "dependencies": {
     "@apollo/client": "^3.5.6",


### PR DESCRIPTION
Add npm/npx scripts whic use apollo CLI https://www.apollographql.com/docs/devtools/cli/

Scripts list:
--- 
- download schema from gql service in two formats: json and gql
- extract client queries in manifest.json file
- generate types in TS format